### PR TITLE
🐛 fix(render): prevent infinite loops in invisible single-item lists

### DIFF
--- a/Virtual.ts
+++ b/Virtual.ts
@@ -185,7 +185,7 @@ export class Virtual {
   }
 
   public onItemResized(key: string | number, size: number) {
-    if (!size || this.sizes.get(key) === size) {
+    if (this.sizes.get(key) === size) {
       return;
     }
 


### PR DESCRIPTION
fix: 修复列表不可见且长度为1时导致的死循环
fixes mfuu/vue-virtual-sortable#38